### PR TITLE
fix: patch Critical + High bugs (FS sandbox escape, FFI/N-API memory safety)

### DIFF
--- a/src/_senri_ffi/call.rs
+++ b/src/_senri_ffi/call.rs
@@ -235,6 +235,10 @@ pub mod async_defs {
             middle::Cif::new_with_abi(middle_arg_types, middle_ret_type, abi)
         };
 
+        // `cb_datas` owns the ChannelCallbackData backing each proxy closure so
+        // it is freed when this function returns (previously it was leaked once
+        // per async call). Declared before `closures` so the closures drop first.
+        let mut cb_datas: Vec<Box<ChannelCallbackData>> = Vec::new();
         let mut closures: Vec<middle::Closure> = Vec::new();
         let mut adjusted_buffers: Vec<Vec<u8>> = Vec::with_capacity(arg_buffers.len());
 
@@ -249,9 +253,10 @@ pub mod async_defs {
                 let tx = callback_tx.clone();
                 let tid = task_id;
 
-                let proxy = create_channel_callback_closure(cb_args, *cb_ret, tx, tid, cb_index, callback_timeout_ms)?;
+                let (proxy, cb_data) = create_channel_callback_closure(cb_args, *cb_ret, tx, tid, cb_index, callback_timeout_ms)?;
                 let code_ptr = *proxy.code_ptr() as usize;
                 closures.push(proxy);
+                cb_datas.push(cb_data);
                 let addr_bytes = code_ptr.to_le_bytes().to_vec();
                 adjusted_buffers.push(addr_bytes);
             } else {
@@ -395,7 +400,7 @@ pub mod async_defs {
         task_id: u64,
         cb_index: usize,
         _timeout_ms: u64,
-    ) -> Result<middle::Closure<'static>, String> {
+    ) -> Result<(middle::Closure<'static>, Box<ChannelCallbackData>), String> {
         let middle_arg_types: Vec<middle::Type> = arg_types.iter().map(|t| t.to_middle_type()).collect();
         let middle_ret_type = ret_type.to_middle_type();
         let cif = middle::Cif::new(middle_arg_types, middle_ret_type);
@@ -411,9 +416,16 @@ pub mod async_defs {
             cb_index,
             ret_size,
         });
-        let data_ref: &'static ChannelCallbackData = Box::leak(data);
+        // Own the data (returned to the caller) rather than leaking it. The heap
+        // address is stable across the move, so the &'static reference handed to
+        // the closure stays valid for as long as the returned Box is kept alive.
+        let data_ptr: *const ChannelCallbackData = &*data;
+        let data_ref: &'static ChannelCallbackData = unsafe { &*data_ptr };
 
-        Ok(middle::Closure::new(cif, channel_cb_trampoline::<*mut std::ffi::c_void>, data_ref))
+        Ok((
+            middle::Closure::new(cif, channel_cb_trampoline::<*mut std::ffi::c_void>, data_ref),
+            data,
+        ))
     }
 }
 

--- a/src/_senri_ffi/callback.rs
+++ b/src/_senri_ffi/callback.rs
@@ -23,6 +23,9 @@ thread_local! {
 
 struct CallbackEntry {
     _closure: middle::Closure<'static>,
+    // Raw owner of the CallbackData the closure references. Dropped *after* the
+    // closure in `free_callback` so the trampoline never touches freed data.
+    data_ptr: *mut CallbackData,
 }
 
 struct CallbackData {
@@ -54,14 +57,19 @@ pub fn create_callback(
         func: RefCell::new(Some(js_func)),
     });
 
-    let data_ref: &'static CallbackData = Box::leak(data);
+    // Keep ownership of the CallbackData so it can be reclaimed by
+    // `free_callback` rather than leaking permanently. The heap address is
+    // stable, so the &'static reference handed to the closure stays valid until
+    // the registry entry (and thus this allocation) is removed.
+    let data_ptr: *mut CallbackData = Box::into_raw(data);
+    let data_ref: &'static CallbackData = unsafe { &*data_ptr };
 
     let closure = middle::Closure::new(cif, trampoline::<CallResultBuf>, data_ref);
     let code = *closure.code_ptr() as *const c_void;
 
     let addr = code as usize;
     CALLBACK_REGISTRY.with(|reg| {
-        reg.borrow_mut().insert(addr, CallbackEntry { _closure: closure });
+        reg.borrow_mut().insert(addr, CallbackEntry { _closure: closure, data_ptr });
     });
 
     let ptr_obj = create_pointer_object(addr, 0, ctx);
@@ -69,11 +77,14 @@ pub fn create_callback(
     Ok(ptr_obj)
 }
 
-#[allow(dead_code)]
-fn free_callback(addr: usize) -> bool {
+pub fn free_callback(addr: usize) -> bool {
     CALLBACK_REGISTRY.with(|reg| {
         if let Some(entry) = reg.borrow_mut().remove(&addr) {
-            drop(entry);
+            let CallbackEntry { _closure, data_ptr } = entry;
+            // Drop the closure first so the trampoline can no longer run, then
+            // reclaim the CallbackData it referenced.
+            drop(_closure);
+            unsafe { drop(Box::from_raw(data_ptr)); }
             true
         } else {
             false

--- a/src/_senri_ffi/mod.rs
+++ b/src/_senri_ffi/mod.rs
@@ -284,6 +284,27 @@ pub fn register_senri_ffi(context: &mut Context, instance_ptr: *mut c_void) {
     );
     builder.function(create_cb_fn, js_string!("createCallback"), 3);
 
+    // freeCallback(ptr) -> bool : release a callback previously produced by
+    // createCallback, reclaiming its libffi closure and CallbackData. Without
+    // this the callback allocation would live for the entire process.
+    let free_cb_fn = NativeFunction::from_copy_closure(
+        move |_this: &JsValue, args: &[JsValue], _ctx: &mut Context| -> Result<JsValue, JsError> {
+            let addr = args
+                .first()
+                .and_then(|v| {
+                    if let Some(obj) = v.as_object() {
+                        obj.downcast_ref::<crate::_senri_ffi::pointer::JsPointer>()
+                            .map(|p| p.address)
+                    } else {
+                        v.as_number().map(|n| n as usize)
+                    }
+                })
+                .unwrap_or(0);
+            Ok(JsValue::from(callback::free_callback(addr)))
+        },
+    );
+    builder.function(free_cb_fn, js_string!("freeCallback"), 1);
+
     register_memory_methods(&mut builder);
 
     let senri_obj = builder.build();

--- a/src/_senri_ffi/struct_def.rs
+++ b/src/_senri_ffi/struct_def.rs
@@ -393,3 +393,49 @@ pub fn create_struct_constructor(
 fn js_function_to_object(f: boa_engine::object::builtins::JsFunction) -> JsObject {
     JsObject::from(f)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{write_to_buffer, FfiType};
+    use boa_engine::{js_string, JsValue};
+
+    /// C2 regression: a CString struct field stores a `char*` into the buffer.
+    /// The owning CString must be retained (in `keep`) so the pointer does not
+    /// dangle. Here we verify the pointer is non-null and, while the CString is
+    /// alive, points to the exact input bytes.
+    #[test]
+    fn test_cstring_field_pointer_kept_alive() {
+        let t = FfiType::CString;
+        let mut buf = vec![0u8; t.sizeof()];
+        let mut keep: Vec<std::ffi::CString> = Vec::new();
+        let val = JsValue::from(js_string!("hello"));
+
+        write_to_buffer(&mut buf, 0, &t, &val, &mut keep).unwrap();
+
+        // The CString must be retained rather than dropped at end of write.
+        assert_eq!(keep.len(), 1, "CString must be retained to avoid a dangling char*");
+
+        let ptr = usize::from_le_bytes(
+            buf[..std::mem::size_of::<usize>()].try_into().unwrap(),
+        );
+        assert_ne!(ptr, 0, "stored char* must be non-null");
+        let s = unsafe { std::ffi::CStr::from_ptr(ptr as *const std::ffi::c_char) };
+        assert_eq!(s.to_str().unwrap(), "hello");
+    }
+
+    /// A null/undefined CString field writes a null pointer and retains nothing.
+    #[test]
+    fn test_cstring_field_null_is_zero() {
+        let t = FfiType::CString;
+        let mut buf = vec![0xFFu8; t.sizeof()];
+        let mut keep: Vec<std::ffi::CString> = Vec::new();
+
+        write_to_buffer(&mut buf, 0, &t, &JsValue::null(), &mut keep).unwrap();
+
+        assert_eq!(keep.len(), 0);
+        let ptr = usize::from_le_bytes(
+            buf[..std::mem::size_of::<usize>()].try_into().unwrap(),
+        );
+        assert_eq!(ptr, 0, "null CString field must write a null pointer");
+    }
+}

--- a/src/_senri_ffi/struct_def.rs
+++ b/src/_senri_ffi/struct_def.rs
@@ -21,6 +21,11 @@ use super::types::{self, compute_struct_layout, FfiType};
 struct StructInstance {
     #[unsafe_ignore_trace]
     buffer: Vec<u8>,
+    /// CString fields store a `char*` into `buffer`; the owning CString must
+    /// live as long as this instance, otherwise the stored pointer dangles
+    /// (use-after-free) when the struct is later passed to native code.
+    #[unsafe_ignore_trace]
+    cstrings: Vec<std::ffi::CString>,
 }
 
 fn read_from_buffer(buf: &[u8], offset: usize, type_info: &FfiType) -> JsValue {
@@ -94,7 +99,13 @@ fn read_from_buffer(buf: &[u8], offset: usize, type_info: &FfiType) -> JsValue {
     }
 }
 
-fn write_to_buffer(buf: &mut [u8], offset: usize, type_info: &FfiType, val: &JsValue) -> Result<(), JsError> {
+fn write_to_buffer(
+    buf: &mut [u8],
+    offset: usize,
+    type_info: &FfiType,
+    val: &JsValue,
+    keep: &mut Vec<std::ffi::CString>,
+) -> Result<(), JsError> {
     let end = offset + type_info.sizeof();
     if end > buf.len() {
         return Err(JsNativeError::error().with_message("buffer overflow").into());
@@ -196,6 +207,9 @@ fn write_to_buffer(buf: &mut [u8], offset: usize, type_info: &FfiType, val: &JsV
                 })?;
                 let ptr = cstr.as_ptr() as usize;
                 target.copy_from_slice(&ptr.to_le_bytes());
+                // Keep the CString alive for the lifetime of the owning buffer so
+                // the stored char* does not dangle once passed to native code.
+                keep.push(cstr);
             }
             Ok(())
         }
@@ -253,7 +267,11 @@ pub fn create_struct_constructor(
                     })?;
                     let default_val = JsValue::undefined();
                     let val = args.first().unwrap_or(&default_val);
-                    write_to_buffer(&mut inst.buffer, f_offset, &f_type2, val)?;
+                    // Split-borrow disjoint fields so the buffer and the CString
+                    // collector can be borrowed mutably at the same time.
+                    let inst_ref: &mut StructInstance = &mut inst;
+                    let StructInstance { buffer, cstrings } = inst_ref;
+                    write_to_buffer(buffer, f_offset, &f_type2, val, cstrings)?;
                     Ok(JsValue::undefined())
                 },
             )
@@ -307,6 +325,7 @@ pub fn create_struct_constructor(
         NativeFunction::from_closure(
             move |_this: &JsValue, args: &[JsValue], _ctx: &mut Context| -> Result<JsValue, JsError> {
                 let mut buffer = vec![0u8; total_size_for_ctor];
+                let mut cstrings: Vec<std::ffi::CString> = Vec::new();
 
                 if let Some(init_obj) = args.first().and_then(|v| v.as_object()) {
                     for field in &fields_for_ctor {
@@ -320,6 +339,7 @@ pub fn create_struct_constructor(
                                     field.offset,
                                     &field.type_info,
                                     val,
+                                    &mut cstrings,
                                 )?;
                             }
                         }
@@ -327,7 +347,7 @@ pub fn create_struct_constructor(
                 }
 
                 let buffer_ptr = buffer.as_ptr() as usize;
-                let instance = StructInstance { buffer };
+                let instance = StructInstance { buffer, cstrings };
                 let obj = JsObject::from_proto_and_data(
                     proto_for_ctor.clone(),
                     instance,

--- a/src/embedded_stdlib.rs
+++ b/src/embedded_stdlib.rs
@@ -513,6 +513,25 @@ function _b64decToString(b64) {
   return chars.join('');
 }
 
+// Standard base64 encode (with padding) of a byte array / Uint8Array.
+function _b64enc(bytes) {
+  var out = '';
+  var i = 0;
+  for (; i + 2 < bytes.length; i += 3) {
+    var n = (bytes[i] << 16) | (bytes[i + 1] << 8) | bytes[i + 2];
+    out += _b64c[(n >> 18) & 63] + _b64c[(n >> 12) & 63] + _b64c[(n >> 6) & 63] + _b64c[n & 63];
+  }
+  var rem = bytes.length - i;
+  if (rem === 1) {
+    var m = bytes[i] << 16;
+    out += _b64c[(m >> 18) & 63] + _b64c[(m >> 12) & 63] + '==';
+  } else if (rem === 2) {
+    var k = (bytes[i] << 16) | (bytes[i + 1] << 8);
+    out += _b64c[(k >> 18) & 63] + _b64c[(k >> 12) & 63] + _b64c[(k >> 6) & 63] + '=';
+  }
+  return out;
+}
+
 function readFileSyncUtf8(path) {
   if (typeof __koss_fs_read === 'function') {
     var raw = __koss_fs_read(path);
@@ -539,19 +558,20 @@ function readFileSync(path) {
 
 function writeFileSync(path, data) {
   if (typeof __koss_fs_write === 'function') {
-    var dataStr;
-    if (typeof data === 'string') {
-      dataStr = data;
-    } else if (data instanceof Uint8Array) {
-      var chars = [];
-      for (var i = 0; i < data.length; i++) chars.push(String.fromCharCode(data[i]));
-      dataStr = chars.join('');
-    } else if (data && data.toString) {
-      dataStr = data.toString();
+    // Binary data (a Uint8Array, or a Node Buffer wrapping one) is transmitted
+    // as base64 so bytes >= 0x80 survive the JS<->native string boundary; a
+    // latin1/utf8 string round-trip would otherwise corrupt them.
+    var u8 = null;
+    if (data instanceof Uint8Array) u8 = data;
+    else if (data && data._data instanceof Uint8Array) u8 = data._data;
+    var raw;
+    if (u8) {
+      raw = __koss_fs_write(path, _b64enc(u8), true);
     } else {
-      dataStr = String(data);
+      var dataStr = (typeof data === 'string') ? data
+        : (data && data.toString ? data.toString() : String(data));
+      raw = __koss_fs_write(path, dataStr, false);
     }
-    var raw = __koss_fs_write(path, dataStr);
     var result = parseResult(raw);
     throwIfError(result, 'Failed to write file: ' + path);
     return result && result.value;

--- a/src/js_shims/internal/fs.js
+++ b/src/js_shims/internal/fs.js
@@ -55,6 +55,25 @@ function _b64decToString(b64) {
   return chars.join('');
 }
 
+// Standard base64 encode (with padding) of a byte array / Uint8Array.
+function _b64enc(bytes) {
+  var out = '';
+  var i = 0;
+  for (; i + 2 < bytes.length; i += 3) {
+    var n = (bytes[i] << 16) | (bytes[i + 1] << 8) | bytes[i + 2];
+    out += _b64c[(n >> 18) & 63] + _b64c[(n >> 12) & 63] + _b64c[(n >> 6) & 63] + _b64c[n & 63];
+  }
+  var rem = bytes.length - i;
+  if (rem === 1) {
+    var m = bytes[i] << 16;
+    out += _b64c[(m >> 18) & 63] + _b64c[(m >> 12) & 63] + '==';
+  } else if (rem === 2) {
+    var k = (bytes[i] << 16) | (bytes[i + 1] << 8);
+    out += _b64c[(k >> 18) & 63] + _b64c[(k >> 12) & 63] + _b64c[(k >> 6) & 63] + '=';
+  }
+  return out;
+}
+
 function readFileSyncUtf8(path) {
   if (typeof __koss_fs_read === 'function') {
     var raw = __koss_fs_read(path);
@@ -81,19 +100,20 @@ function readFileSync(path) {
 
 function writeFileSync(path, data) {
   if (typeof __koss_fs_write === 'function') {
-    var dataStr;
-    if (typeof data === 'string') {
-      dataStr = data;
-    } else if (data instanceof Uint8Array) {
-      var chars = [];
-      for (var i = 0; i < data.length; i++) chars.push(String.fromCharCode(data[i]));
-      dataStr = chars.join('');
-    } else if (data && data.toString) {
-      dataStr = data.toString();
+    // Binary data (a Uint8Array, or a Node Buffer wrapping one) is transmitted
+    // as base64 so bytes >= 0x80 survive the JS<->native string boundary; a
+    // latin1/utf8 string round-trip would otherwise corrupt them.
+    var u8 = null;
+    if (data instanceof Uint8Array) u8 = data;
+    else if (data && data._data instanceof Uint8Array) u8 = data._data;
+    var raw;
+    if (u8) {
+      raw = __koss_fs_write(path, _b64enc(u8), true);
     } else {
-      dataStr = String(data);
+      var dataStr = (typeof data === 'string') ? data
+        : (data && data.toString ? data.toString() : String(data));
+      raw = __koss_fs_write(path, dataStr, false);
     }
-    var raw = __koss_fs_write(path, dataStr);
     var result = parseResult(raw);
     throwIfError(result, 'Failed to write file: ' + path);
     return result && result.value;

--- a/src/napi/functions/array.rs
+++ b/src/napi/functions/array.rs
@@ -10,7 +10,7 @@ use boa_engine::{Context, JsValue};
 
 use super::super::env::{NapiEnv, NapiValue};
 use super::super::status::NapiStatus;
-use super::super::value::get_value_as;
+use super::super::value::{alloc_slot, get_value_as, NapiSlot};
 use super::object::value_to_js;
 
 pub unsafe fn napi_create_array(
@@ -23,8 +23,8 @@ pub unsafe fn napi_create_array(
     let obj = js_val.as_object().map(|o| o.clone()).unwrap_or_else(|| {
         boa_engine::JsObject::with_object_proto(ctx.intrinsics())
     });
-    let boxed = Box::new(obj);
-    *result = Box::into_raw(boxed) as NapiValue;
+    let boxed_obj = obj;
+    *result = alloc_slot(NapiSlot::Object(boxed_obj));
     NapiStatus::Ok
 }
 
@@ -40,8 +40,8 @@ pub unsafe fn napi_create_array_with_length(
     let obj = js_val.as_object().map(|o| o.clone()).unwrap_or_else(|| {
         boa_engine::JsObject::with_object_proto(ctx.intrinsics())
     });
-    let boxed = Box::new(obj);
-    *result = Box::into_raw(boxed) as NapiValue;
+    let boxed_obj = obj;
+    *result = alloc_slot(NapiSlot::Object(boxed_obj));
     NapiStatus::Ok
 }
 

--- a/src/napi/functions/buffer.rs
+++ b/src/napi/functions/buffer.rs
@@ -6,49 +6,45 @@
 
 use std::ffi::c_void;
 
-use boa_engine::{Context, JsObject, JsValue};
-
 use super::super::env::{NapiEnv, NapiValue};
 use super::super::status::NapiStatus;
+use super::super::value::{alloc_slot, as_slot, NapiSlot};
 
 pub unsafe fn napi_create_buffer(
-    env: *mut NapiEnv,
+    _env: *mut NapiEnv,
     length: usize,
     data: *mut *mut c_void,
     result: *mut NapiValue,
 ) -> NapiStatus {
-    let ctx = unsafe { &mut *(*env).ctx };
-    let mut buffer = vec![0u8; length];
-    let ptr = buffer.as_mut_ptr();
-    let mut boxed = Box::new(buffer);
+    let mut vec = vec![0u8; length];
+    let ptr = vec.as_mut_ptr();
     if !data.is_null() {
-        *data = boxed.as_mut_ptr() as *mut c_void;
+        *data = ptr as *mut c_void;
     }
-
-    let data_addr = boxed.as_ptr() as usize;
-    *result = data_addr as NapiValue;
-    std::mem::forget(boxed);
+    // The Vec is owned by the slot; moving the Vec does not move its heap
+    // allocation, so `ptr` (and the length) stay valid for the slot's lifetime.
+    *result = alloc_slot(NapiSlot::Buffer(vec));
     NapiStatus::Ok
 }
 
 pub unsafe fn napi_create_buffer_copy(
-    env: *mut NapiEnv,
+    _env: *mut NapiEnv,
     length: usize,
     data: *const c_void,
-    _result_data: *mut *mut c_void,
+    result_data: *mut *mut c_void,
     result: *mut NapiValue,
 ) -> NapiStatus {
-    let ctx = unsafe { &mut *(*env).ctx };
-    let mut buffer = vec![0u8; length];
+    let mut vec = vec![0u8; length];
     if !data.is_null() {
         unsafe {
-            std::ptr::copy_nonoverlapping(data as *const u8, buffer.as_mut_ptr(), length);
+            std::ptr::copy_nonoverlapping(data as *const u8, vec.as_mut_ptr(), length);
         }
     }
-    let ptr = buffer.as_ptr() as usize;
-    let boxed = Box::new(buffer);
-    std::mem::forget(boxed);
-    *result = ptr as NapiValue;
+    let ptr = vec.as_mut_ptr();
+    if !result_data.is_null() {
+        *result_data = ptr as *mut c_void;
+    }
+    *result = alloc_slot(NapiSlot::Buffer(vec));
     NapiStatus::Ok
 }
 
@@ -58,14 +54,16 @@ pub unsafe fn napi_get_buffer_info(
     data: *mut *mut c_void,
     length: *mut usize,
 ) -> NapiStatus {
-    if value.is_null() || (value as usize) < 4096 {
-        return NapiStatus::InvalidArg;
+    match unsafe { as_slot(value) } {
+        Some(NapiSlot::Buffer(v)) => {
+            if !data.is_null() {
+                *data = v.as_ptr() as *mut c_void;
+            }
+            if !length.is_null() {
+                *length = v.len();
+            }
+            NapiStatus::Ok
+        }
+        _ => NapiStatus::InvalidArg,
     }
-    if !data.is_null() {
-        *data = value;
-    }
-    if !length.is_null() {
-        *length = 0;
-    }
-    NapiStatus::Ok
 }

--- a/src/napi/functions/class.rs
+++ b/src/napi/functions/class.rs
@@ -10,7 +10,7 @@ use std::ffi::c_void;
 
 use super::super::env::{NapiCallback, NapiEnv, NapiPropertyDescriptor, NapiValue};
 use super::super::status::NapiStatus;
-use super::super::value::get_value_as;
+use super::super::value::{alloc_slot, get_value_as, NapiSlot};
 use super::function::napi_create_function;
 
 thread_local! {
@@ -49,8 +49,7 @@ pub unsafe fn napi_define_class(
     });
 
     let obj = boa_engine::JsObject::with_object_proto(_ctx.intrinsics());
-    let boxed = Box::new(obj);
-    *result = Box::into_raw(boxed) as NapiValue;
+    *result = alloc_slot(NapiSlot::Object(obj));
     NapiStatus::Ok
 }
 

--- a/src/napi/functions/error.rs
+++ b/src/napi/functions/error.rs
@@ -80,8 +80,9 @@ pub unsafe fn napi_get_and_clear_last_exception(
     let err = unsafe { (*env).take_error() };
     match err {
         Some((_, msg)) => {
-            let cstr = CString::new(msg).unwrap_or_default();
-            *result = cstr.into_raw() as NapiValue;
+            let cstr = CString::new(msg.clone())
+                .unwrap_or_else(|_| CString::new(msg.replace('\0', "")).unwrap_or_default());
+            *result = super::super::value::alloc_slot(super::super::value::NapiSlot::Str(cstr));
             NapiStatus::Ok
         }
         None => {

--- a/src/napi/functions/external.rs
+++ b/src/napi/functions/external.rs
@@ -8,6 +8,7 @@ use std::ffi::c_void;
 
 use super::super::env::{NapiEnv, NapiValue};
 use super::super::status::NapiStatus;
+use super::super::value::{alloc_slot, as_slot, NapiSlot};
 
 pub unsafe fn napi_create_external(
     _env: *mut NapiEnv,
@@ -16,7 +17,9 @@ pub unsafe fn napi_create_external(
     _finalize_hint: *mut c_void,
     result: *mut NapiValue,
 ) -> NapiStatus {
-    *result = data;
+    // Wrap the opaque pointer in a tagged slot so it is never mistaken for a
+    // number/string/object value when decoded elsewhere.
+    *result = alloc_slot(NapiSlot::External(data));
     NapiStatus::Ok
 }
 
@@ -25,6 +28,14 @@ pub unsafe fn napi_get_value_external(
     value: NapiValue,
     result: *mut *mut c_void,
 ) -> NapiStatus {
-    *result = value;
-    NapiStatus::Ok
+    match unsafe { as_slot(value) } {
+        Some(NapiSlot::External(d)) => {
+            *result = *d;
+            NapiStatus::Ok
+        }
+        _ => {
+            *result = std::ptr::null_mut();
+            NapiStatus::InvalidArg
+        }
+    }
 }

--- a/src/napi/functions/function.rs
+++ b/src/napi/functions/function.rs
@@ -45,23 +45,10 @@ pub unsafe fn napi_create_function(
                 let cb = CALLBACK_REGISTRY.with(|reg| reg.borrow().get(&cb_id).copied());
                 match cb {
                     Some(callback) => {
-                        let mut napi_args: Vec<NapiValue> = args.iter().map(|a| {
-                            if a.is_undefined() { std::ptr::null_mut() }
-                            else if a.is_null() { 1usize as NapiValue }
-                            else if let Some(b) = a.as_boolean() {
-                                if b { 2usize as NapiValue } else { 3usize as NapiValue }
-                            } else if let Some(n) = a.as_number() {
-                                let boxed = Box::new(n);
-                                Box::into_raw(boxed) as NapiValue
-                            } else if let Some(s) = a.as_string() {
-                                let cstr = std::ffi::CString::new(s.to_std_string_escaped()).unwrap_or_default();
-                                cstr.into_raw() as NapiValue
-                            } else if let Some(o) = a.as_object() {
-                                Box::into_raw(Box::new(o.clone())) as NapiValue
-                            } else {
-                                std::ptr::null_mut()
-                            }
-                        }).collect();
+                        let mut napi_args: Vec<NapiValue> = Vec::with_capacity(args.len());
+                        for a in args {
+                            napi_args.push(unsafe { super::super::value::js_to_napi(a, _ctx) });
+                        }
 
                         let cb_data = CALLBACK_DATA.with(|reg| reg.borrow().get(&cb_id).copied().unwrap_or(std::ptr::null_mut()));
 
@@ -74,12 +61,16 @@ pub unsafe fn napi_create_function(
                             data: cb_data,
                         };
 
-                        let ret = callback(env, &info as *const NapiCallbackInfo as *mut NapiCallbackInfo);
-                        if ret.is_null() {
-                            Ok(JsValue::undefined())
-                        } else {
-                            Ok(value_to_js(ret, _ctx))
+                        let ret = unsafe { callback(env, &info as *const NapiCallbackInfo as *mut NapiCallbackInfo) };
+                        let js_ret = value_to_js(ret, _ctx);
+                        // Callback-scoped argument slots are valid only for the
+                        // duration of the call; free them now to avoid a per-call
+                        // leak. Persisting a value requires napi_create_reference,
+                        // which stores an independent copy.
+                        for a in &napi_args {
+                            unsafe { super::super::value::free_value(*a) };
                         }
+                        Ok(js_ret)
                     }
                     None => Err(JsNativeError::error().with_message("callback not found").into()),
                 }
@@ -87,9 +78,7 @@ pub unsafe fn napi_create_function(
         )
     };
     let js_func = closure.to_js_function(ctx.realm());
-    let obj = JsObject::from(js_func);
-    let boxed = Box::new(obj);
-    *result = Box::into_raw(boxed) as NapiValue;
+    *result = super::super::value::alloc_slot(super::super::value::NapiSlot::Object(JsObject::from(js_func)));
     NapiStatus::Ok
 }
 
@@ -188,8 +177,21 @@ pub unsafe fn napi_new_instance(
         let val = unsafe { *argv.add(i) };
         args.push(value_to_js(val, ctx));
     }
-    let new_obj = JsObject::with_object_proto(ctx.intrinsics());
-    let boxed = Box::new(new_obj);
-    *result = Box::into_raw(boxed) as NapiValue;
-    NapiStatus::Ok
+    // Actually invoke the constructor (previously the constructor and its
+    // arguments were ignored and an empty object was returned). Call it with a
+    // fresh receiver and return its result object, falling back to the receiver.
+    let ctor = match boa_engine::object::builtins::JsFunction::from_object(obj.clone()) {
+        Some(f) => f,
+        None => return NapiStatus::FunctionExpected,
+    };
+    let this_obj = JsObject::with_object_proto(ctx.intrinsics());
+    let this_val = JsValue::from(this_obj.clone());
+    match ctor.call(&this_val, &args, ctx) {
+        Ok(ret) => {
+            let instance = ret.as_object().unwrap_or(this_obj);
+            *result = super::super::value::alloc_slot(super::super::value::NapiSlot::Object(instance));
+            NapiStatus::Ok
+        }
+        Err(_) => NapiStatus::GenericFailure,
+    }
 }

--- a/src/napi/functions/object.rs
+++ b/src/napi/functions/object.rs
@@ -10,7 +10,7 @@ use boa_engine::{js_string, JsValue};
 
 use super::super::env::{NapiEnv, NapiPropertyDescriptor, NapiValue, NAPI_CONFIGURABLE, NAPI_ENUMERABLE, NAPI_WRITABLE};
 use super::super::status::NapiStatus;
-use super::super::value::get_value_as;
+use super::super::value::{alloc_slot, as_slot, get_value_as, NapiSlot};
 
 pub unsafe fn napi_create_object(
     _env: *mut NapiEnv,
@@ -18,8 +18,7 @@ pub unsafe fn napi_create_object(
 ) -> NapiStatus {
     let ctx = unsafe { &mut *(*_env).ctx };
     let obj = boa_engine::JsObject::with_object_proto(ctx.intrinsics());
-    let boxed = Box::new(obj);
-    *result = Box::into_raw(boxed) as NapiValue;
+    *result = alloc_slot(NapiSlot::Object(obj));
     NapiStatus::Ok
 }
 
@@ -153,53 +152,22 @@ pub unsafe fn napi_define_properties(
 }
 
 fn key_value_to_string(key: NapiValue) -> String {
-    if key.is_null() {
-        return String::new();
+    match unsafe { as_slot(key) } {
+        Some(NapiSlot::Str(cstr)) => cstr.to_string_lossy().to_string(),
+        Some(NapiSlot::Number(n)) => format!("{}", *n as i64),
+        _ => String::new(),
     }
-    let addr = key as usize;
-    if addr > 0x10000 {
-        if let Ok(cstr) = unsafe { std::ffi::CStr::from_ptr(key as *const std::ffi::c_char) }.to_str() {
-            return cstr.to_string();
-        }
-    }
-    if addr < 4096 && addr > 0 {
-        let n: f64 = unsafe { *(key as *const f64) };
-        return format!("{}", n as i64);
-    }
-    String::new()
 }
 
 fn napi_value_from_cstr(ptr: *const u8) -> NapiValue {
     let cstr = unsafe { std::ffi::CStr::from_ptr(ptr as *const std::ffi::c_char) };
     let s = cstr.to_string_lossy().to_string();
     let cstring = std::ffi::CString::new(s).unwrap_or_default();
-    cstring.into_raw() as NapiValue
+    alloc_slot(NapiSlot::Str(cstring))
 }
 
-pub fn value_to_js(val: NapiValue, _ctx: &mut boa_engine::Context) -> JsValue {
-    if val.is_null() {
-        return JsValue::undefined();
-    }
-    let addr = val as usize;
-    if addr == 1 {
-        return JsValue::null();
-    }
-    if addr == 2 {
-        return JsValue::from(true);
-    }
-    if addr == 3 {
-        return JsValue::from(false);
-    }
-    if addr < 4096 {
-        let n: f64 = unsafe { *(val as *const f64) };
-        return JsValue::from(n);
-    }
-    if addr > 0x10000 {
-        if let Ok(cstr) = unsafe { std::ffi::CStr::from_ptr(val as *const std::ffi::c_char) }.to_str() {
-            return JsValue::from(js_string!(cstr));
-        }
-    }
-    JsValue::undefined()
+pub fn value_to_js(val: NapiValue, ctx: &mut boa_engine::Context) -> JsValue {
+    unsafe { super::super::value::value_to_js(val, ctx) }
 }
 
 pub fn js_value_to_napi_value(js: &JsValue, _ctx: &mut boa_engine::Context) -> NapiValue {

--- a/src/napi/functions/primitives.rs
+++ b/src/napi/functions/primitives.rs
@@ -4,20 +4,19 @@
 // with the TT23XR Studio Additional Permission:
 // "非本软件模块的源代码公开义务例外"
 
-use std::ffi::c_void;
-
-use boa_engine::{js_string, Context, JsObject, JsValue};
-
 use super::super::env::{NapiEnv, NapiValue};
 use super::super::status::NapiStatus;
+use super::super::value::{
+    alloc_slot, as_slot, get_napi_value_type, napi_bool, napi_null, napi_undefined, NapiSlot,
+    NAPI_FALSE, NAPI_TRUE,
+};
 
 pub unsafe fn napi_create_number(
     _env: *mut NapiEnv,
     value: f64,
     result: *mut NapiValue,
 ) -> NapiStatus {
-    let boxed = Box::new(value);
-    *result = Box::into_raw(boxed) as NapiValue;
+    *result = alloc_slot(NapiSlot::Number(value));
     NapiStatus::Ok
 }
 
@@ -58,7 +57,7 @@ pub unsafe fn napi_create_bool(
     value: bool,
     result: *mut NapiValue,
 ) -> NapiStatus {
-    *result = if value { 2usize as NapiValue } else { 3usize as NapiValue };
+    *result = napi_bool(value);
     NapiStatus::Ok
 }
 
@@ -66,7 +65,7 @@ pub unsafe fn napi_create_null(
     _env: *mut NapiEnv,
     result: *mut NapiValue,
 ) -> NapiStatus {
-    *result = 1usize as NapiValue;
+    *result = napi_null();
     NapiStatus::Ok
 }
 
@@ -74,7 +73,7 @@ pub unsafe fn napi_create_undefined(
     _env: *mut NapiEnv,
     result: *mut NapiValue,
 ) -> NapiStatus {
-    *result = std::ptr::null_mut::<c_void>();
+    *result = napi_undefined();
     NapiStatus::Ok
 }
 
@@ -83,12 +82,13 @@ pub unsafe fn napi_get_value_int32(
     value: NapiValue,
     result: *mut i32,
 ) -> NapiStatus {
-    if value.is_null() || (value as usize) < 4096 {
-        return NapiStatus::NumberExpected;
+    match unsafe { as_slot(value) } {
+        Some(NapiSlot::Number(n)) => {
+            *result = *n as i32;
+            NapiStatus::Ok
+        }
+        _ => NapiStatus::NumberExpected,
     }
-    let n: f64 = unsafe { *(value as *const f64) };
-    *result = n as i32;
-    NapiStatus::Ok
 }
 
 pub unsafe fn napi_get_value_int64(
@@ -96,12 +96,13 @@ pub unsafe fn napi_get_value_int64(
     value: NapiValue,
     result: *mut i64,
 ) -> NapiStatus {
-    if value.is_null() || (value as usize) < 4096 {
-        return NapiStatus::NumberExpected;
+    match unsafe { as_slot(value) } {
+        Some(NapiSlot::Number(n)) => {
+            *result = *n as i64;
+            NapiStatus::Ok
+        }
+        _ => NapiStatus::NumberExpected,
     }
-    let n: f64 = unsafe { *(value as *const f64) };
-    *result = n as i64;
-    NapiStatus::Ok
 }
 
 pub unsafe fn napi_get_value_double(
@@ -109,11 +110,13 @@ pub unsafe fn napi_get_value_double(
     value: NapiValue,
     result: *mut f64,
 ) -> NapiStatus {
-    if value.is_null() || (value as usize) < 4096 {
-        return NapiStatus::NumberExpected;
+    match unsafe { as_slot(value) } {
+        Some(NapiSlot::Number(n)) => {
+            *result = *n;
+            NapiStatus::Ok
+        }
+        _ => NapiStatus::NumberExpected,
     }
-    *result = unsafe { *(value as *const f64) };
-    NapiStatus::Ok
 }
 
 pub unsafe fn napi_get_value_bool(
@@ -122,10 +125,10 @@ pub unsafe fn napi_get_value_bool(
     result: *mut bool,
 ) -> NapiStatus {
     let addr = value as usize;
-    if addr == 2 {
+    if addr == NAPI_TRUE {
         *result = true;
         NapiStatus::Ok
-    } else if addr == 3 {
+    } else if addr == NAPI_FALSE {
         *result = false;
         NapiStatus::Ok
     } else {
@@ -138,18 +141,7 @@ pub unsafe fn napi_typeof(
     value: NapiValue,
     result: *mut i32,
 ) -> NapiStatus {
-    let addr = value as usize;
-    *result = if value.is_null() {
-        0 // undefined
-    } else if addr == 1 {
-        1 // null
-    } else if addr == 2 || addr == 3 {
-        4 // boolean
-    } else if addr < 4096 {
-        5 // number
-    } else {
-        6 // object (catch-all for string/function/external)
-    };
+    *result = get_napi_value_type(value);
     NapiStatus::Ok
 }
 

--- a/src/napi/functions/reference.rs
+++ b/src/napi/functions/reference.rs
@@ -6,11 +6,11 @@
 
 use std::cell::RefCell;
 use std::collections::HashMap;
-use std::ffi::c_void;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use super::super::env::{NapiEnv, NapiValue};
 use super::super::status::NapiStatus;
+use super::super::value::{clone_value, free_value, napi_undefined};
 
 thread_local! {
     static REF_COUNTS: RefCell<HashMap<usize, (NapiValue, u32)>> = RefCell::new(HashMap::new());
@@ -21,14 +21,19 @@ static NEXT_REF_ID: AtomicUsize = AtomicUsize::new(1);
 pub unsafe fn napi_create_reference(
     _env: *mut NapiEnv,
     value: NapiValue,
-    _initial_refcount: u32,
+    initial_refcount: u32,
     result: *mut NapiValue,
 ) -> NapiStatus {
     let id = NEXT_REF_ID.fetch_add(1, Ordering::Relaxed);
+    // Store an independent copy so the reference stays valid even after the
+    // (callback-scoped) source value is freed.
+    let owned = unsafe { clone_value(value) };
     REF_COUNTS.with(|reg| {
-        reg.borrow_mut().insert(id, (value, 1));
+        reg.borrow_mut().insert(id, (owned, initial_refcount));
     });
-    *result = id as NapiValue;
+    if !result.is_null() {
+        *result = id as NapiValue;
+    }
     NapiStatus::Ok
 }
 
@@ -37,7 +42,10 @@ pub unsafe fn napi_delete_reference(
     reference: NapiValue,
 ) -> NapiStatus {
     let id = reference as usize;
-    REF_COUNTS.with(|reg| { reg.borrow_mut().remove(&id); });
+    let removed = REF_COUNTS.with(|reg| reg.borrow_mut().remove(&id));
+    if let Some((owned, _)) = removed {
+        unsafe { free_value(owned) };
+    }
     NapiStatus::Ok
 }
 
@@ -48,12 +56,18 @@ pub unsafe fn napi_reference_ref(
 ) -> NapiStatus {
     let id = reference as usize;
     REF_COUNTS.with(|reg| {
-        if let Some((_, count)) = reg.borrow_mut().get_mut(&id) {
-            *count += 1;
-            *result = *count;
+        let mut map = reg.borrow_mut();
+        match map.get_mut(&id) {
+            Some((_, count)) => {
+                *count += 1;
+                if !result.is_null() {
+                    unsafe { *result = *count; }
+                }
+                NapiStatus::Ok
+            }
+            None => NapiStatus::InvalidArg,
         }
-    });
-    NapiStatus::Ok
+    })
 }
 
 pub unsafe fn napi_reference_unref(
@@ -63,14 +77,20 @@ pub unsafe fn napi_reference_unref(
 ) -> NapiStatus {
     let id = reference as usize;
     REF_COUNTS.with(|reg| {
-        if let Some((_, count)) = reg.borrow_mut().get_mut(&id) {
-            if *count > 0 {
-                *count -= 1;
+        let mut map = reg.borrow_mut();
+        match map.get_mut(&id) {
+            Some((_, count)) => {
+                if *count > 0 {
+                    *count -= 1;
+                }
+                if !result.is_null() {
+                    unsafe { *result = *count; }
+                }
+                NapiStatus::Ok
             }
-            *result = *count;
+            None => NapiStatus::InvalidArg,
         }
-    });
-    NapiStatus::Ok
+    })
 }
 
 pub unsafe fn napi_get_reference_value(
@@ -78,10 +98,20 @@ pub unsafe fn napi_get_reference_value(
     reference: NapiValue,
     result: *mut NapiValue,
 ) -> NapiStatus {
+    if result.is_null() {
+        return NapiStatus::InvalidArg;
+    }
     let id = reference as usize;
     REF_COUNTS.with(|reg| {
-        if let Some((val, _)) = reg.borrow().get(&id) {
-            *result = *val;
+        match reg.borrow().get(&id) {
+            Some((val, _)) => {
+                unsafe { *result = *val; }
+            }
+            None => {
+                // Reference not found (e.g. already deleted): report undefined
+                // rather than leaving the out-parameter uninitialized.
+                unsafe { *result = napi_undefined(); }
+            }
         }
     });
     NapiStatus::Ok

--- a/src/napi/functions/string.rs
+++ b/src/napi/functions/string.rs
@@ -8,6 +8,7 @@ use std::ffi::CString;
 
 use super::super::env::{NapiEnv, NapiValue};
 use super::super::status::NapiStatus;
+use super::super::value::{alloc_slot, as_slot, napi_undefined, NapiSlot};
 
 pub unsafe fn napi_create_string_utf8(
     _env: *mut NapiEnv,
@@ -16,7 +17,7 @@ pub unsafe fn napi_create_string_utf8(
     result: *mut NapiValue,
 ) -> NapiStatus {
     if str.is_null() {
-        *result = std::ptr::null_mut();
+        *result = napi_undefined();
         return NapiStatus::InvalidArg;
     }
     let len = if length < 0 {
@@ -31,12 +32,14 @@ pub unsafe fn napi_create_string_utf8(
         length
     };
     let bytes = unsafe { std::slice::from_raw_parts(str, len as usize) };
-    if let Ok(s) = std::str::from_utf8(bytes) {
-        let cstr = CString::new(s).unwrap_or_default();
-        *result = cstr.into_raw() as NapiValue;
-        NapiStatus::Ok
-    } else {
-        NapiStatus::GenericFailure
+    match std::str::from_utf8(bytes) {
+        Ok(s) => {
+            let cstr = CString::new(s)
+                .unwrap_or_else(|_| CString::new(s.replace('\0', "")).unwrap_or_default());
+            *result = alloc_slot(NapiSlot::Str(cstr));
+            NapiStatus::Ok
+        }
+        Err(_) => NapiStatus::GenericFailure,
     }
 }
 
@@ -56,21 +59,30 @@ pub unsafe fn napi_get_value_string_utf8(
     bufsize: usize,
     result: *mut usize,
 ) -> NapiStatus {
-    if value.is_null() || (value as usize) < 4096 {
-        return NapiStatus::StringExpected;
-    }
-    let cstr = unsafe { std::ffi::CStr::from_ptr(value as *const std::ffi::c_char) };
-    let s = cstr.to_string_lossy();
-    let bytes = s.as_bytes();
-    let copy_len = bytes.len().min(bufsize - 1);
-    if !buf.is_null() && bufsize > 0 {
-        unsafe {
-            std::ptr::copy_nonoverlapping(bytes.as_ptr(), buf, copy_len);
-            *buf.add(copy_len) = 0;
+    let cstr = match unsafe { as_slot(value) } {
+        Some(NapiSlot::Str(c)) => c,
+        _ => return NapiStatus::StringExpected,
+    };
+    let bytes = cstr.as_bytes();
+
+    // When no buffer is provided (or size 0) the caller only wants the required
+    // length. Compute it without the `bufsize - 1` subtraction, which would
+    // underflow (panic in debug) when bufsize == 0.
+    if buf.is_null() || bufsize == 0 {
+        if !result.is_null() {
+            *result = bytes.len();
         }
+        return NapiStatus::Ok;
+    }
+
+    let copy_len = bytes.len().min(bufsize - 1);
+    unsafe {
+        std::ptr::copy_nonoverlapping(bytes.as_ptr(), buf, copy_len);
+        *buf.add(copy_len) = 0;
     }
     if !result.is_null() {
-        *result = bytes.len();
+        // Number of bytes written excluding the trailing NUL.
+        *result = copy_len;
     }
     NapiStatus::Ok
 }

--- a/src/napi/value.rs
+++ b/src/napi/value.rs
@@ -4,88 +4,242 @@
 // with the TT23XR Studio Additional Permission:
 // "非本软件模块的源代码公开义务例外"
 
-use std::ffi::{c_void, CString};
-use std::os::raw::c_char;
+//! Unified N-API value representation.
+//!
+//! Previously `NapiValue` was a raw pointer whose meaning was guessed from its
+//! numeric address range (`< 4096` => boxed f64, `> 0x10000` => C string, etc.).
+//! Because numbers, strings and objects are all heap pointers, those ranges
+//! overlapped: a boxed number was routinely mis-read as a C string, producing
+//! type confusion and out-of-bounds reads.
+//!
+//! Every non-trivial value is now a tagged [`NapiSlot`] allocated on the heap.
+//! Small sentinel integers encode `undefined`/`null`/`true`/`false` so pointer
+//! identity for those keeps working. Any other `NapiValue` is a `*mut NapiSlot`.
 
-use boa_engine::{js_string, Context, JsError, JsNativeError, JsObject, JsValue};
+use std::ffi::{c_void, CString};
+
+use boa_engine::{js_string, Context, JsError, JsObject, JsValue};
 
 use super::env::{NapiEnv, NapiValue};
 use super::status::NapiStatus;
 
-pub unsafe fn js_to_napi(js: &JsValue, ctx: &mut Context) -> NapiValue {
+// Sentinel encodings. These small integers are never valid heap pointers, so
+// they can be distinguished from a `*mut NapiSlot` by numeric value.
+pub const NAPI_UNDEFINED: usize = 0;
+pub const NAPI_NULL: usize = 1;
+pub const NAPI_TRUE: usize = 2;
+pub const NAPI_FALSE: usize = 3;
+const MAX_SENTINEL: usize = 3;
+
+/// Tagged heap payload behind a non-sentinel [`NapiValue`].
+pub enum NapiSlot {
+    Number(f64),
+    Str(CString),
+    Object(JsObject),
+    Buffer(Vec<u8>),
+    External(*mut c_void),
+}
+
+#[inline]
+pub fn alloc_slot(slot: NapiSlot) -> NapiValue {
+    Box::into_raw(Box::new(slot)) as NapiValue
+}
+
+#[inline]
+pub fn napi_undefined() -> NapiValue {
+    NAPI_UNDEFINED as NapiValue
+}
+
+#[inline]
+pub fn napi_null() -> NapiValue {
+    NAPI_NULL as NapiValue
+}
+
+#[inline]
+pub fn napi_bool(b: bool) -> NapiValue {
+    (if b { NAPI_TRUE } else { NAPI_FALSE }) as NapiValue
+}
+
+/// Borrow the [`NapiSlot`] behind a non-sentinel value, if any.
+///
+/// # Safety
+/// `v` must be either a sentinel or a pointer previously produced by
+/// [`alloc_slot`] (which is the invariant maintained by every producer in this
+/// crate). Sentinels return `None` without dereferencing.
+#[inline]
+pub unsafe fn as_slot<'a>(v: NapiValue) -> Option<&'a NapiSlot> {
+    let addr = v as usize;
+    if addr <= MAX_SENTINEL {
+        return None;
+    }
+    Some(unsafe { &*(v as *const NapiSlot) })
+}
+
+/// Convert a Boa [`JsValue`] into a fresh [`NapiValue`].
+pub unsafe fn js_to_napi(js: &JsValue, _ctx: &mut Context) -> NapiValue {
     if js.is_undefined() {
-        return std::ptr::null_mut::<c_void>();
+        return napi_undefined();
     }
     if js.is_null() {
-        return 1usize as NapiValue;
+        return napi_null();
     }
     if let Some(b) = js.as_boolean() {
-        return if b { 2usize as NapiValue } else { 3usize as NapiValue };
+        return napi_bool(b);
     }
     if let Some(n) = js.as_number() {
-        let boxed = Box::new(n);
-        return Box::into_raw(boxed) as NapiValue;
+        return alloc_slot(NapiSlot::Number(n));
     }
     if let Some(s) = js.as_string() {
         let s = s.to_std_string_escaped();
-        let cstr = CString::new(s).unwrap_or_default();
-        return cstr.into_raw() as NapiValue;
+        // Strings with interior NULs cannot round-trip through a C string; fall
+        // back to storing the truncated form rather than silently losing all data.
+        let cstr = CString::new(s.clone())
+            .unwrap_or_else(|_| CString::new(s.replace('\0', "")).unwrap_or_default());
+        return alloc_slot(NapiSlot::Str(cstr));
     }
-    js.as_object().map(|obj| {
-        Box::into_raw(Box::new(obj.clone())) as NapiValue
-    }).unwrap_or(std::ptr::null_mut::<c_void>())
+    if let Some(obj) = js.as_object() {
+        return alloc_slot(NapiSlot::Object(obj.clone()));
+    }
+    napi_undefined()
 }
 
+/// N-API `napi_valuetype`-ish code, preserving this crate's historical mapping
+/// (undefined=0, null=1, boolean=4, number=5, everything-else=6).
 pub fn get_napi_value_type(val: NapiValue) -> i32 {
-    if val.is_null() {
-        0 // napi_undefined
-    } else {
-        let addr = val as usize;
-        if addr == 1 {
-            1 // napi_null
-        } else if addr == 2 || addr == 3 {
-            4 // napi_boolean
-        } else if addr < 4096 {
-            5 // napi_number (boxed)
-        } else {
-            6 // napi_object / napi_function / napi_string / napi_external
-        }
-    }
-}
-
-pub unsafe fn napi_to_js(val: NapiValue, env: *mut NapiEnv, _ctx: &mut Context) -> Result<JsValue, JsError> {
-    if val.is_null() {
-        return Ok(JsValue::undefined());
-    }
     let addr = val as usize;
-    if addr == 1 {
-        return Ok(JsValue::null());
+    match addr {
+        NAPI_UNDEFINED => 0,
+        NAPI_NULL => 1,
+        NAPI_TRUE | NAPI_FALSE => 4,
+        _ => match unsafe { as_slot(val) } {
+            Some(NapiSlot::Number(_)) => 5,
+            _ => 6,
+        },
     }
-    if addr == 2 {
-        return Ok(JsValue::from(true));
-    }
-    if addr == 3 {
-        return Ok(JsValue::from(false));
-    }
-    if addr < 4096 {
-        let n: f64 = unsafe { *(val as *const f64) };
-        return Ok(JsValue::from(n));
-    }
-    if addr > 0x10000 {
-        let cstr = unsafe { std::ffi::CStr::from_ptr(val as *const c_char) };
-        if let Ok(s) = cstr.to_str() {
-            return Ok(JsValue::from(js_string!(s)));
-        }
-    }
-    Ok(JsValue::undefined())
 }
 
-pub unsafe fn get_value_as(obj: NapiValue) -> Option<boa_engine::JsObject> {
-    if obj.is_null() || (obj as usize) < 4096 {
-        return None;
+/// Shared decode used by both `napi_to_js` and `object::value_to_js`.
+pub unsafe fn value_to_js(val: NapiValue, ctx: &mut Context) -> JsValue {
+    let addr = val as usize;
+    match addr {
+        NAPI_UNDEFINED => JsValue::undefined(),
+        NAPI_NULL => JsValue::null(),
+        NAPI_TRUE => JsValue::from(true),
+        NAPI_FALSE => JsValue::from(false),
+        _ => match unsafe { as_slot(val) } {
+            Some(NapiSlot::Number(n)) => JsValue::from(*n),
+            Some(NapiSlot::Str(cstr)) => match cstr.to_str() {
+                Ok(s) => JsValue::from(js_string!(s)),
+                Err(_) => JsValue::undefined(),
+            },
+            Some(NapiSlot::Object(obj)) => JsValue::from(obj.clone()),
+            // Buffer/External have no faithful JsValue representation here; the
+            // dedicated accessors (napi_get_buffer_info / napi_get_value_external)
+            // expose them safely. Returning undefined avoids unsafe reads.
+            Some(NapiSlot::Buffer(_)) | Some(NapiSlot::External(_)) => JsValue::undefined(),
+            None => {
+                let _ = ctx;
+                JsValue::undefined()
+            }
+        },
     }
-    unsafe {
-        let ptr = obj as *const boa_engine::JsObject;
-        Some((*ptr).clone())
+}
+
+pub unsafe fn napi_to_js(val: NapiValue, _env: *mut NapiEnv, ctx: &mut Context) -> Result<JsValue, JsError> {
+    Ok(unsafe { value_to_js(val, ctx) })
+}
+
+/// Return the [`JsObject`] behind an object value, or `None` for anything else.
+pub unsafe fn get_value_as(obj: NapiValue) -> Option<JsObject> {
+    match unsafe { as_slot(obj) } {
+        Some(NapiSlot::Object(o)) => Some(o.clone()),
+        _ => None,
+    }
+}
+
+/// Deep-copy a value into a freshly allocated, independently owned slot.
+/// Sentinels are returned unchanged. Used so that persistent references do not
+/// alias transient (callback-scoped) slots that are freed after the call.
+pub unsafe fn clone_value(v: NapiValue) -> NapiValue {
+    match unsafe { as_slot(v) } {
+        None => v,
+        Some(NapiSlot::Number(n)) => alloc_slot(NapiSlot::Number(*n)),
+        Some(NapiSlot::Str(s)) => alloc_slot(NapiSlot::Str(s.clone())),
+        Some(NapiSlot::Object(o)) => alloc_slot(NapiSlot::Object(o.clone())),
+        Some(NapiSlot::Buffer(b)) => alloc_slot(NapiSlot::Buffer(b.clone())),
+        Some(NapiSlot::External(p)) => alloc_slot(NapiSlot::External(*p)),
+    }
+}
+
+/// Free a slot previously produced by [`alloc_slot`]. No-op for sentinels.
+///
+/// # Safety
+/// The caller must own `v` (no other live alias). Intended for scope-bound
+/// values such as per-call callback arguments.
+pub unsafe fn free_value(v: NapiValue) {
+    let addr = v as usize;
+    if addr > MAX_SENTINEL {
+        drop(unsafe { Box::from_raw(v as *mut NapiSlot) });
+    }
+}
+
+#[allow(dead_code)]
+pub fn napi_status_ok() -> NapiStatus {
+    NapiStatus::Ok
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sentinels_distinct_from_slots() {
+        assert_eq!(get_napi_value_type(napi_undefined()), 0);
+        assert_eq!(get_napi_value_type(napi_null()), 1);
+        assert_eq!(get_napi_value_type(napi_bool(true)), 4);
+        assert_eq!(get_napi_value_type(napi_bool(false)), 4);
+    }
+
+    #[test]
+    fn test_number_not_misclassified() {
+        // A heap-boxed number must report as number (5), not object (6), and must
+        // never be decoded as a string (the historical bug).
+        let v = alloc_slot(NapiSlot::Number(42.5));
+        assert_eq!(get_napi_value_type(v), 5);
+        match unsafe { as_slot(v) } {
+            Some(NapiSlot::Number(n)) => assert_eq!(*n, 42.5),
+            _ => panic!("expected Number slot"),
+        }
+        // reclaim
+        drop(unsafe { Box::from_raw(v as *mut NapiSlot) });
+    }
+
+    #[test]
+    fn test_string_slot_roundtrip() {
+        let v = alloc_slot(NapiSlot::Str(CString::new("hello").unwrap()));
+        assert_eq!(get_napi_value_type(v), 6);
+        match unsafe { as_slot(v) } {
+            Some(NapiSlot::Str(s)) => assert_eq!(s.to_str().unwrap(), "hello"),
+            _ => panic!("expected Str slot"),
+        }
+        drop(unsafe { Box::from_raw(v as *mut NapiSlot) });
+    }
+
+    #[test]
+    fn test_buffer_slot_tracks_length() {
+        let v = alloc_slot(NapiSlot::Buffer(vec![1, 2, 3, 4]));
+        match unsafe { as_slot(v) } {
+            Some(NapiSlot::Buffer(b)) => assert_eq!(b.len(), 4),
+            _ => panic!("expected Buffer slot"),
+        }
+        drop(unsafe { Box::from_raw(v as *mut NapiSlot) });
+    }
+
+    #[test]
+    fn test_as_slot_none_for_sentinels() {
+        assert!(unsafe { as_slot(napi_undefined()) }.is_none());
+        assert!(unsafe { as_slot(napi_null()) }.is_none());
+        assert!(unsafe { as_slot(napi_bool(true)) }.is_none());
+        assert!(unsafe { as_slot(napi_bool(false)) }.is_none());
     }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1124,10 +1124,25 @@ fn is_ssrf_blocked(host: &str) -> bool {
 }
 
 fn register_fs_functions(instance: &mut KossInstance) {
+    // Capability snapshot: the low-level __koss_fs_* globals are gated by the
+    // instance capability bitmask so sandboxed instances cannot bypass the
+    // sandbox via these globals (mirrors the NET_FETCH gate on __koss_fetch).
+    let caps = instance.capabilities;
     macro_rules! reg_fs {
-        ($name:expr, $closure:expr) => {{
-            let js_fn = NativeFunction::from_copy_closure($closure)
-                .to_js_function(instance.context.realm());
+        ($name:expr, $cap:expr, $closure:expr) => {{
+            let inner = $closure;
+            let required_cap: u32 = $cap;
+            let js_fn = NativeFunction::from_copy_closure(
+                move |this: &JsValue, args: &[JsValue], ctx: &mut Context| -> Result<JsValue, JsError> {
+                    if !crate::sandbox::has_cap(caps, required_cap) {
+                        return Err(JsNativeError::error()
+                            .with_message(concat!($name, ": permission denied (missing required FS capability)"))
+                            .into());
+                    }
+                    inner(this, args, ctx)
+                },
+            )
+            .to_js_function(instance.context.realm());
             instance.context.register_global_property(
                 boa_engine::js_string!($name),
                 js_fn,
@@ -1137,14 +1152,14 @@ fn register_fs_functions(instance: &mut KossInstance) {
     }
 
     // __koss_fs_exists(path) -> bool
-    reg_fs!("__koss_fs_exists", |_this: &JsValue, args: &[JsValue], ctx: &mut Context| -> Result<JsValue, JsError> {
+    reg_fs!("__koss_fs_exists", crate::sandbox::FS_READ, |_this: &JsValue, args: &[JsValue], ctx: &mut Context| -> Result<JsValue, JsError> {
         let path = args.first().ok_or_else(|| JsNativeError::error().with_message("exists: path required"))?
             .to_string(ctx).map_err(|_| JsNativeError::error().with_message("exists: path must be string"))?;
         Ok(JsValue::from(crate::bindings::fs::exists_sync(&path.to_std_string_escaped())))
     });
 
     // __koss_fs_read(path) -> { code: 0, value: base64_string }
-    reg_fs!("__koss_fs_read", |_this: &JsValue, args: &[JsValue], ctx: &mut Context| -> Result<JsValue, JsError> {
+    reg_fs!("__koss_fs_read", crate::sandbox::FS_READ, |_this: &JsValue, args: &[JsValue], ctx: &mut Context| -> Result<JsValue, JsError> {
         let path = args.first().ok_or_else(|| JsNativeError::error().with_message("read: path required"))?
             .to_string(ctx).map_err(|_| JsNativeError::error().with_message("read: path must be string"))?;
         let path_str = path.to_std_string_escaped();
@@ -1158,24 +1173,36 @@ fn register_fs_functions(instance: &mut KossInstance) {
         }
     });
 
-    // __koss_fs_write(path, data) -> { code: 0 }
-    reg_fs!("__koss_fs_write", |_this: &JsValue, args: &[JsValue], ctx: &mut Context| -> Result<JsValue, JsError> {
+    // __koss_fs_write(path, data, is_base64) -> { code: 0 }
+    // When is_base64 is true, `data` is a base64 string that is decoded to raw
+    // bytes before writing. This keeps binary writes lossless (a latin1/utf8
+    // string round-trip would corrupt any byte >= 0x80).
+    reg_fs!("__koss_fs_write", crate::sandbox::FS_WRITE, |_this: &JsValue, args: &[JsValue], ctx: &mut Context| -> Result<JsValue, JsError> {
         if args.len() < 2 {
             return Err(JsNativeError::error().with_message("write: path and data required").into());
         }
         let path = args[0].to_string(ctx).map_err(|_| JsNativeError::error().with_message("write: path must be string"))?;
         let data_val = args[1].to_string(ctx).map_err(|_| JsNativeError::error().with_message("write: data must be string"))?;
+        let is_base64 = args.get(2).map(|v| v.to_boolean()).unwrap_or(false);
         let path_str = path.to_std_string_escaped();
         let data_str = data_val.to_std_string_escaped();
-        let bytes = data_str.as_bytes();
-        match std::fs::write(&path_str, bytes) {
+        let bytes: Vec<u8> = if is_base64 {
+            use base64::Engine;
+            match base64::engine::general_purpose::STANDARD.decode(data_str.as_bytes()) {
+                Ok(b) => b,
+                Err(_) => return Ok(JsValue::from(boa_engine::js_string!("{\"code\":1,\"value\":\"invalid base64 data\"}"))),
+            }
+        } else {
+            data_str.into_bytes()
+        };
+        match std::fs::write(&path_str, &bytes) {
             Ok(()) => Ok(JsValue::from(boa_engine::js_string!("{\"code\":0}"))),
             Err(e) => Ok(JsValue::from(boa_engine::js_string!(format!("{{\"code\":1,\"value\":\"{}\"}}", e)))),
         }
     });
 
     // __koss_fs_stat(path) -> { code: 0, value: json_string }
-    reg_fs!("__koss_fs_stat", |_this: &JsValue, args: &[JsValue], ctx: &mut Context| -> Result<JsValue, JsError> {
+    reg_fs!("__koss_fs_stat", crate::sandbox::FS_READ, |_this: &JsValue, args: &[JsValue], ctx: &mut Context| -> Result<JsValue, JsError> {
         let path = args.first().ok_or_else(|| JsNativeError::error().with_message("stat: path required"))?
             .to_string(ctx).map_err(|_| JsNativeError::error().with_message("stat: path must be string"))?;
         let path_str = path.to_std_string_escaped();
@@ -1198,7 +1225,11 @@ fn register_fs_functions(instance: &mut KossInstance) {
     });
 
     // __koss_fs_mkdir(path, recursive) -> { code: 0 }
-    reg_fs!("__koss_fs_mkdir", |_this: &JsValue, args: &[JsValue], ctx: &mut Context| -> Result<JsValue, JsError> {
+    // NOTE: gated on FS_WRITE rather than FS_MKDIR because FS_MKDIR (1<<3)
+    // collides with the legacy KOSS_CAP_WORKER alias (also 1<<3), which stable
+    // mode strips — so FS_MKDIR is unusable there. Directory creation is a write
+    // operation, so FS_WRITE is the appropriate (and non-colliding) capability.
+    reg_fs!("__koss_fs_mkdir", crate::sandbox::FS_WRITE, |_this: &JsValue, args: &[JsValue], ctx: &mut Context| -> Result<JsValue, JsError> {
         let path = args.first().ok_or_else(|| JsNativeError::error().with_message("mkdir: path required"))?
             .to_string(ctx).map_err(|_| JsNativeError::error().with_message("mkdir: path must be string"))?;
         let recursive = args.get(1).and_then(|v| v.as_number()).map(|n| n != 0.0).unwrap_or(false);
@@ -1215,7 +1246,7 @@ fn register_fs_functions(instance: &mut KossInstance) {
     });
 
     // __koss_fs_readdir(path) -> { code: 0, value: json_array }
-    reg_fs!("__koss_fs_readdir", |_this: &JsValue, args: &[JsValue], ctx: &mut Context| -> Result<JsValue, JsError> {
+    reg_fs!("__koss_fs_readdir", crate::sandbox::FS_READ, |_this: &JsValue, args: &[JsValue], ctx: &mut Context| -> Result<JsValue, JsError> {
         let path = args.first().ok_or_else(|| JsNativeError::error().with_message("readdir: path required"))?
             .to_string(ctx).map_err(|_| JsNativeError::error().with_message("readdir: path must be string"))?;
         let path_str = path.to_std_string_escaped();
@@ -1232,7 +1263,7 @@ fn register_fs_functions(instance: &mut KossInstance) {
     });
 
     // __koss_fs_unlink(path) -> { code: 0 }
-    reg_fs!("__koss_fs_unlink", |_this: &JsValue, args: &[JsValue], ctx: &mut Context| -> Result<JsValue, JsError> {
+    reg_fs!("__koss_fs_unlink", crate::sandbox::FS_DELETE, |_this: &JsValue, args: &[JsValue], ctx: &mut Context| -> Result<JsValue, JsError> {
         let path = args.first().ok_or_else(|| JsNativeError::error().with_message("unlink: path required"))?
             .to_string(ctx).map_err(|_| JsNativeError::error().with_message("unlink: path must be string"))?;
         let path_str = path.to_std_string_escaped();
@@ -1244,7 +1275,7 @@ fn register_fs_functions(instance: &mut KossInstance) {
     });
 
     // __koss_fs_rename(old, new) -> { code: 0 }
-    reg_fs!("__koss_fs_rename", |_this: &JsValue, args: &[JsValue], ctx: &mut Context| -> Result<JsValue, JsError> {
+    reg_fs!("__koss_fs_rename", crate::sandbox::FS_RENAME, |_this: &JsValue, args: &[JsValue], ctx: &mut Context| -> Result<JsValue, JsError> {
         if args.len() < 2 {
             return Err(JsNativeError::error().with_message("rename: old and new path required").into());
         }
@@ -1257,7 +1288,7 @@ fn register_fs_functions(instance: &mut KossInstance) {
     });
 
     // __koss_fs_copy(src, dst) -> { code: 0 }
-    reg_fs!("__koss_fs_copy", |_this: &JsValue, args: &[JsValue], ctx: &mut Context| -> Result<JsValue, JsError> {
+    reg_fs!("__koss_fs_copy", crate::sandbox::FS_WRITE, |_this: &JsValue, args: &[JsValue], ctx: &mut Context| -> Result<JsValue, JsError> {
         if args.len() < 2 {
             return Err(JsNativeError::error().with_message("copy: src and dst required").into());
         }
@@ -1270,7 +1301,7 @@ fn register_fs_functions(instance: &mut KossInstance) {
     });
 
     // __koss_fs_realpath(path) -> path string
-    reg_fs!("__koss_fs_realpath", |_this: &JsValue, args: &[JsValue], ctx: &mut Context| -> Result<JsValue, JsError> {
+    reg_fs!("__koss_fs_realpath", crate::sandbox::FS_READ, |_this: &JsValue, args: &[JsValue], ctx: &mut Context| -> Result<JsValue, JsError> {
         let path = args.first().ok_or_else(|| JsNativeError::error().with_message("realpath: path required"))?
             .to_string(ctx).map_err(|_| JsNativeError::error().with_message("realpath: path must be string"))?;
         let path_str = path.to_std_string_escaped();

--- a/test/test_sandbox_fs.py
+++ b/test/test_sandbox_fs.py
@@ -1,0 +1,84 @@
+"""FS 沙箱测试 - 验证 FS 能力位对 __koss_fs_* 全局函数的控制
+
+修复项 C1：低层 __koss_fs_* 全局函数此前无条件注册且不检查能力位，
+导致 KOSS_CAP_SANDBOX（零权限）实例仍可读写/删除任意文件。
+现改为按 FS_READ/FS_WRITE/FS_DELETE/FS_MKDIR/FS_RENAME 门控。
+"""
+import os
+import pytest  # pyright: ignore[reportUnusedImport]
+from kossjs_interface import KossJS
+
+
+# 通过 JS try/catch 返回哨兵字符串，避免依赖错误如何传播到 Python。
+_PROBE = "(function(){{try{{{body};return 'ok';}}catch(e){{return 'denied';}}}})()"
+
+
+def _probe(js: str) -> str:
+    return _PROBE.format(body=js)
+
+
+# ── 拒绝：无能力位时应抛错 ────────────────────────────────────────────
+
+def test_fs_read_denied_in_sandbox():
+    """KOSS_CAP_SANDBOX 下 __koss_fs_read 应抛出权限错误。"""
+    js = KossJS(capabilities=KossJS.KOSS_CAP_SANDBOX)
+    try:
+        assert js.eval(_probe("__koss_fs_read('nonexistent.txt')")) == "denied"
+    finally:
+        js.destroy()
+
+
+def test_fs_write_denied_in_sandbox():
+    """KOSS_CAP_SANDBOX 下 __koss_fs_write 应抛出权限错误。"""
+    js = KossJS(capabilities=KossJS.KOSS_CAP_SANDBOX)
+    try:
+        assert js.eval(_probe("__koss_fs_write('x.txt','data')")) == "denied"
+    finally:
+        js.destroy()
+
+
+def test_fs_write_denied_with_read_only():
+    """仅授予 FS_READ 时，写操作仍应被拒绝。"""
+    js = KossJS(capabilities=KossJS.FS_READ)
+    try:
+        assert js.eval(_probe("__koss_fs_read('nonexistent.txt')")) == "ok"
+        assert js.eval(_probe("__koss_fs_write('x.txt','data')")) == "denied"
+        assert js.eval(_probe("__koss_fs_mkdir('d',0)")) == "denied"
+        assert js.eval(_probe("__koss_fs_unlink('x.txt')")) == "denied"
+    finally:
+        js.destroy()
+
+
+# ── 放行：授予对应能力位后应可用 ──────────────────────────────────────
+
+def test_fs_read_allowed_with_cap():
+    """授予 FS_READ 后 __koss_fs_read 不再抛权限错误（缺失文件返回 code!=0 字符串）。"""
+    js = KossJS(capabilities=KossJS.FS_READ)
+    try:
+        assert js.eval(_probe("__koss_fs_read('nonexistent.txt')")) == "ok"
+    finally:
+        js.destroy()
+
+
+def test_fs_roundtrip_with_caps(tmp_path):
+    """授予 FS_READ|FS_WRITE 后可写入并读回文件内容（验证完整路径）。"""
+    target = str(tmp_path / "koss_fs_test.txt").replace("\\", "/")
+    js = KossJS(capabilities=KossJS.FS_READ | KossJS.FS_WRITE)
+    try:
+        write_ok = js.eval(_probe(f"__koss_fs_write('{target}','hello-koss')"))
+        assert write_ok == "ok"
+        assert os.path.exists(target)
+        with open(target, "r", encoding="utf-8") as f:
+            assert f.read() == "hello-koss"
+    finally:
+        js.destroy()
+
+
+def test_fs_available_with_all_caps():
+    """默认 KOSS_CAP_ALL 实例的 fs 全局函数不应被门控拦截（无回归）。"""
+    js = KossJS(capabilities=KossJS.KOSS_CAP_ALL)
+    try:
+        assert js.eval(_probe("__koss_fs_read('nonexistent.txt')")) == "ok"
+        assert js.eval(_probe("__koss_fs_stat('nonexistent.txt')")) == "ok"
+    finally:
+        js.destroy()


### PR DESCRIPTION
﻿## Summary
Fixes 10 Critical/High-severity bugs found during a review of the runtime, native FFI (Senri) and N-API layers. Organized into 5 topic commits. All existing tests pass and new tests were added.

## Critical
- **C1 - Filesystem sandbox escape:** the low-level `__koss_fs_*` globals were registered unconditionally with no capability check, so a `KOSS_CAP_SANDBOX` (zero-capability) instance could still read/write/delete arbitrary files. Each op is now gated by the instance capability bitmask (`FS_READ`/`FS_WRITE`/`FS_DELETE`/`FS_RENAME`). Adds `test/test_sandbox_fs.py`.
- **C2 - FFI struct `CString` use-after-free:** the `char*` written into a struct buffer referenced a `CString` dropped immediately after, dangling when the struct was later passed to native code. `StructInstance` now retains the `CString`s.
- **C3 - N-API value type confusion / OOB read:** value kind was inferred from pointer address ranges (`<4096` / `>0x10000`), conflating heap-boxed numbers, strings and objects and causing out-of-bounds reads. Replaced with a tagged `NapiSlot` representation; all producers/consumers updated.

## High
- **H1** - N-API `reference` funcs null-check `result` and handle missing ids; references keep an independent copy.
- **H2** - `napi_get_value_string_utf8` no longer integer-underflows when `bufsize == 0`.
- **H3** - Buffers carry their length; `napi_get_buffer_info` returns real data/length.
- **H4** - `napi_new_instance` actually invokes the constructor.
- **H5** - Per-call N-API callback argument slots are freed after the callback returns.
- **H6** - Binary file writes are lossless: `Uint8Array`/`Buffer` are sent as base64 and decoded natively, fixing latin1/utf8 corruption of bytes >= 0x80.
- **H7** - FFI callbacks no longer leak: `create_callback` retains ownership and `free_callback` (exposed as `_senri_ffi.freeCallback`) reclaims the closure + data; async channel-callback data is owned by the call.

## Note (out of scope - possible follow-up)
`FS_MKDIR (1<<3)` collides with the legacy `KOSS_CAP_WORKER` alias (`1<<3`), which stable mode strips - making `FS_MKDIR` unusable there. `mkdir` is therefore gated on `FS_WRITE` in this PR; giving `KOSS_CAP_WORKER` a dedicated bit would be a cleaner long-term fix.

## Testing
- `cargo test --workspace`: 147 passed, 0 failed (includes new N-API value + struct unit tests)
- `python -m pytest test/`: 714 passed, 23 skipped, 0 failed
